### PR TITLE
Alerts using External SMTP Server and CERT, SCAP and NVTs update automatization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.code-workspace
+.env
+.ssh
+.git*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.code-workspace
 .env
-.ssh
-.git*
+

--- a/psql/Dockerfile
+++ b/psql/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:19.04
 COPY conf/openvassd.conf /usr/local/etc/openvas/openvassd.conf
 COPY script/entrypoint.sh /entrypoint.sh
 
-ARG MAILHUB
 ENV DEBIAN_FRONTEND=noninteractive \
     GSE_PASSWORD=admin \
     HOSTNAME=gs \

--- a/psql/Dockerfile
+++ b/psql/Dockerfile
@@ -9,8 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     HOSTNAME=gs \
     SRC_DIR=gse-git \
     SRC_PATH=/root/${SRC_DIR} \
-    PGUSERNAME=root \
-    MAILHUB=${MAILHUB}
+    PGUSERNAME=root
 
 
 RUN apt-get update ;\
@@ -154,10 +153,7 @@ RUN curl --silent --show-error -sS https://dl.yarnpkg.com/debian/pubkey.gpg | su
 COPY script/update.sh /update.sh
 COPY conf/ssmtp.conf /etc/ssmtp/ssmtp.conf
 
-#SSMTP configuration without TLS
-RUN echo "mailhub=${MAILHUB}" >> /etc/ssmtp/ssmtp.conf ;\
-    echo "localhost localhost.localdomain" >> /etc/hosts
-
+#cron update CERT; SCAP; NVTs database
 RUN chmod +x update.sh ;\
     echo "*/1 * * * * /update.sh > /var/log/cron.log 2>&1" >> /etc/cron.d/gvm-cron ;\
     chmod 0644 /etc/cron.d/gvm-cron ;\

--- a/psql/Dockerfile
+++ b/psql/Dockerfile
@@ -155,7 +155,7 @@ COPY conf/ssmtp.conf /etc/ssmtp/ssmtp.conf
 
 #cron update CERT; SCAP; NVTs database
 RUN chmod +x update.sh ;\
-    echo "*/1 * * * * /update.sh > /var/log/cron.log 2>&1" >> /etc/cron.d/gvm-cron ;\
+    echo "0 12 * * SUN /update.sh > /var/log/cron.log 2>&1" >> /etc/cron.d/gvm-cron ;\
     chmod 0644 /etc/cron.d/gvm-cron ;\
     touch /var/log/cron.log ;\
     crontab /etc/cron.d/gvm-cron

--- a/psql/Dockerfile
+++ b/psql/Dockerfile
@@ -3,12 +3,14 @@ FROM ubuntu:19.04
 COPY conf/openvassd.conf /usr/local/etc/openvas/openvassd.conf
 COPY script/entrypoint.sh /entrypoint.sh
 
+ARG MAILHUB
 ENV DEBIAN_FRONTEND=noninteractive \
     GSE_PASSWORD=admin \
     HOSTNAME=gs \
     SRC_DIR=gse-git \
     SRC_PATH=/root/${SRC_DIR} \
-    PGUSERNAME=root
+    PGUSERNAME=root \
+    MAILHUB=${MAILHUB}
 
 
 RUN apt-get update ;\
@@ -140,6 +142,27 @@ RUN cd ${SRC_PATH}/gsa ;\
     make doc-full ;\
     make install ;\
     cd ${SRC_PATH}
+
+#Install ssmtp, cron and nano as cron default editor
+RUN curl --silent --show-error -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - ;\
+    apt-get update && apt-get install -y \
+    ssmtp \
+    nano \
+	cron ;\
+    apt-get clean
+
+COPY script/update.sh /update.sh
+COPY conf/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
+#SSMTP configuration without TLS
+RUN echo "mailhub=${MAILHUB}" >> /etc/ssmtp/ssmtp.conf ;\
+    echo "localhost localhost.localdomain" >> /etc/hosts
+
+RUN chmod +x update.sh ;\
+    echo "*/1 * * * * /update.sh > /var/log/cron.log 2>&1" >> /etc/cron.d/gvm-cron ;\
+    chmod 0644 /etc/cron.d/gvm-cron ;\
+    touch /var/log/cron.log ;\
+    crontab /etc/cron.d/gvm-cron
 
 RUN rm  /root/${SRC_PATH}/ -rf
 

--- a/psql/conf/ssmtp.conf
+++ b/psql/conf/ssmtp.conf
@@ -1,0 +1,4 @@
+hostname=gvm
+UseTLS=NO
+UseSTARTTLS=NO
+FromLineOverride=YES

--- a/psql/conf/ssmtp.conf
+++ b/psql/conf/ssmtp.conf
@@ -2,3 +2,4 @@ hostname=gvm
 UseTLS=NO
 UseSTARTTLS=NO
 FromLineOverride=YES
+

--- a/psql/docker-compose.yml
+++ b/psql/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   
   gvm10:
     image: falkowich/gvm10:psql-latest
+    environment:
+      - MAILHUB=${MAILHUB}
     hostname: gvm
     ports:
       - 443:443

--- a/psql/docker-compose.yml
+++ b/psql/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   
   gvm10:
     image: falkowich/gvm10:psql-latest
+    hostname: gvm
     ports:
       - 443:443
       - 9391:9391

--- a/psql/script/entrypoint.sh
+++ b/psql/script/entrypoint.sh
@@ -66,10 +66,11 @@ gvmd --listen=0.0.0.0 --port=9391
 echo "---> Starting GSAD"
 gsad --mlisten=0.0.0.0 --mport=9391
 
-
+#Starting Cron
+cron 
 
 # WHATTODOWITTHIS?
 if [ -z "$BUILD" ]; then
   echo "Tailing logs"
-  tail -F /usr/local/var/log/gvm/*
+  tail -F /usr/local/var/log/gvm/* -F /var/log/cron.log
 fi

--- a/psql/script/entrypoint.sh
+++ b/psql/script/entrypoint.sh
@@ -66,6 +66,9 @@ gvmd --listen=0.0.0.0 --port=9391
 echo "---> Starting GSAD"
 gsad --mlisten=0.0.0.0 --mport=9391
 
+#SSMTP configuration without TLS
+echo "mailhub=${MAILHUB}" >> /etc/ssmtp/ssmtp.conf;\
+echo "localhost localhost.localdomain" >> /etc/hosts
 #Starting Cron
 cron 
 

--- a/psql/script/entrypoint.sh
+++ b/psql/script/entrypoint.sh
@@ -67,7 +67,7 @@ echo "---> Starting GSAD"
 gsad --mlisten=0.0.0.0 --mport=9391
 
 #SSMTP configuration without TLS
-echo "mailhub=${MAILHUB}" >> /etc/ssmtp/ssmtp.conf;\
+echo -e "\nmailhub=${MAILHUB}" >> /etc/ssmtp/ssmtp.conf
 echo "localhost localhost.localdomain" >> /etc/hosts
 #Starting Cron
 cron 

--- a/psql/script/update.sh
+++ b/psql/script/update.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "---> Starting Certsync.." ;\
+/usr/local/sbin/greenbone-certdata-sync ;\
+echo "---> Starting Scapsync.." ;\
+/usr/local/sbin/greenbone-scapdata-sync ;\
+echo "---> Starting NVTsync.." ;\
+/usr/local/sbin/greenbone-nvt-sync 


### PR DESCRIPTION
Hey, 

This version allows to use the Alert feature of GVM as well as to update the CERT, SCAP and NVTs' database every week.

- Alerts uses ssmtp to communicate with a given external SMTP server.
- Updates is handled with cron and will be run every Sunday at 12:am.

Use following syntax to pass the environment variable for the respective run call: 

With Docker-compose :
Replace <smtp-server> with the smtp server's fully qualified domain name.
`MAILHUB=<smtp-server> docker-compose up -d`

With Docker run:
Replace <smtp-server> with the smtp server's fully qualified domain name. **IMPORTANT:** must be run with **--hostname gvm** .
`docker run \
       -p 443:443 \
       -v gvm:/usr/local/var/lib/gvm \
       -v psql:/var/lib/postgresql/ \
       --name gvm10 \
       --hostname gvm \
       -e MAILHUB=<smtp-server> -d
       falkowich/gvm10:psql`

Further information:
- Currently the update is run for a predefined and fixed day and time.  Maybe give the user the possibility to pass the day and time.
